### PR TITLE
Fix spelling of Midea in all instances

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -37,7 +37,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .midea.core.discover import discover
 from .midea.core.cloud import get_midea_cloud
-from .midea.core.device import MiedaDevice
+from .midea.core.device import MideaDevice
 from .midea_devices import MIDEA_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
@@ -264,7 +264,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             return await self.async_step_auto(error="preset_account")
                     keys = await self.cloud.get_keys(user_input[CONF_DEVICE])
                     for method, key in keys.items():
-                        dm = MiedaDevice(
+                        dm = MideaDevice(
                             name="",
                             device_id=device_id,
                             device_type=device.get(CONF_TYPE),
@@ -314,7 +314,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_manually(error="invalid_token")
             if user_input[CONF_PROTOCOL] == 3 and (len(user_input[CONF_TOKEN]) == 0 or len(user_input[CONF_KEY]) == 0):
                 return await self.async_step_manually(error="invalid_token")
-            dm = MiedaDevice(
+            dm = MideaDevice(
                 name="",
                 device_id=user_input[CONF_DEVICE_ID],
                 device_type=user_input[CONF_TYPE],

--- a/custom_components/midea_ac_lan/midea/core/device.py
+++ b/custom_components/midea_ac_lan/midea/core/device.py
@@ -41,7 +41,7 @@ class ParseMessageResult(IntEnum):
     ERROR = 99
 
 
-class MiedaDevice(threading.Thread):
+class MideaDevice(threading.Thread):
     def __init__(self,
                  name: str,
                  device_id: int,

--- a/custom_components/midea_ac_lan/midea/devices/a1/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/a1/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class DeviceAttributes(StrEnum):
     current_temperature = "current_temperature"
 
 
-class MideaA1Device(MiedaDevice):
+class MideaA1Device(MideaDevice):
     _modes = [
         "Manual", "Continuous", "Auto", "Clothes-Dry", "Shoes-Dry"
     ]

--- a/custom_components/midea_ac_lan/midea/devices/ac/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ac/device.py
@@ -15,7 +15,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class DeviceAttributes(StrEnum):
     realtime_power = "realtime_power"
 
 
-class MideaACDevice(MiedaDevice):
+class MideaACDevice(MideaDevice):
     _fresh_air_fan_speeds = {
         0: "Off", 20: "Silent", 40: "Low", 60: "Medium", 80: "High", 100: "Full"
     }

--- a/custom_components/midea_ac_lan/midea/devices/b0/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/b0/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     water_shortage = "water_shortage"
 
 
-class MideaB0Device(MiedaDevice):
+class MideaB0Device(MideaDevice):
     _status = {
         0x01: "Standby", 0x02: "Idle", 0x03: "Working",
         0x04: "Finished", 0x05: "Delay", 0x06: "Paused"

--- a/custom_components/midea_ac_lan/midea/devices/b1/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/b1/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     water_shortage = "water_shortage"
 
 
-class MideaB1Device(MiedaDevice):
+class MideaB1Device(MideaDevice):
     _status = {
         0x01: "Standby", 0x02: "Idle", 0x03: "Working",
         0x04: "Finished", 0x05: "Delay", 0x06: "Paused"

--- a/custom_components/midea_ac_lan/midea/devices/b3/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/b3/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class DeviceAttributes(StrEnum):
     lock = "lock"
 
 
-class MideaB2Device(MiedaDevice):
+class MideaB2Device(MideaDevice):
     _status = {
         0x00: "Off", 0x01: "Standby", 0x02: "Working",
         0x03: "Delay", 0x04: "Finished"

--- a/custom_components/midea_ac_lan/midea/devices/b4/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/b4/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     water_shortage = "water_shortage"
 
 
-class MideaB4Device(MiedaDevice):
+class MideaB4Device(MideaDevice):
     _status = {
         0x01: "Standby", 0x02: "Idle", 0x03: "Working",
         0x04: "Finished", 0x05: "Delay", 0x06: "Paused"

--- a/custom_components/midea_ac_lan/midea/devices/b6/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/b6/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class DeviceAttributes(StrEnum):
     cleaning_reminder = "cleaning_reminder"
 
 
-class MideaB6Device(MiedaDevice):
+class MideaB6Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/bf/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/bf/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     water_shortage = "water_shortage"
 
 
-class MideaBFDevice(MiedaDevice):
+class MideaBFDevice(MideaDevice):
     _status = {
         0x01: "PowerSave", 0x02: "Standby", 0x03: "Working",
         0x04: "Finished", 0x05: "Delay", 0x06: "Paused"

--- a/custom_components/midea_ac_lan/midea/devices/c2/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/c2/device.py
@@ -10,7 +10,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class DeviceAttributes(StrEnum):
     filter_life = "filter_life"
 
 
-class MideaC2Device(MiedaDevice):
+class MideaC2Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/c3/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/c3/device.py
@@ -10,7 +10,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ class DeviceAttributes(StrEnum):
     error_code = "error_code"
 
 
-class MideaC3Device(MiedaDevice):
+class MideaC3Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/ca/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ca/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class DeviceAttributes(StrEnum):
     flex_zone_door = "flex_zone_door"
 
 
-class MideaCADevice(MiedaDevice):
+class MideaCADevice(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/cc/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/cc/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class DeviceAttributes(StrEnum):
     temp_fahrenheit = "temp_fahrenheit"
 
 
-class MideaCCDevice(MiedaDevice):
+class MideaCCDevice(MideaDevice):
     _fan_speeds_7level = {
         0x01: "Level 1", 0x02: "Level 2", 0x04: "Level 3",
         0x08: "Level 4", 0x10: "Level 5", 0x20: "Level 6",

--- a/custom_components/midea_ac_lan/midea/devices/cd/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/cd/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class DeviceAttributes(StrEnum):
     compressor_status = "compressor_status"
 
 
-class MideaCDDevice(MiedaDevice):
+class MideaCDDevice(MideaDevice):
     _modes = ["Energy-save", "Standard", "Dual", "Smart"]
 
     def __init__(

--- a/custom_components/midea_ac_lan/midea/devices/ce/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ce/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class DeviceAttributes(StrEnum):
     error_code = "error_code"
 
 
-class MideaCEDevice(MiedaDevice):
+class MideaCEDevice(MideaDevice):
     _modes = [
         "Normal", "Sleep mode", "ECO mode"
     ]

--- a/custom_components/midea_ac_lan/midea/devices/cf/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/cf/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class DeviceAttributes(StrEnum):
     min_temperature = "min_temperature"
 
 
-class MideaCFDevice(MiedaDevice):
+class MideaCFDevice(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/da/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/da/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class DeviceAttributes(StrEnum):
     detergent = "detergent"
     
 
-class MideaDADevice(MiedaDevice):
+class MideaDADevice(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/db/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/db/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     time_remaining = "time_remaining"
 
 
-class MideaDBDevice(MiedaDevice):
+class MideaDBDevice(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/dc/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/dc/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     time_remaining = "time_remaining"
 
 
-class MideaDADevice(MiedaDevice):
+class MideaDADevice(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/e1/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/e1/device.py
@@ -10,7 +10,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class DeviceAttributes(StrEnum):
     bright = "bright"
 
 
-class MideaE1Device(MiedaDevice):
+class MideaE1Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/e2/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/e2/device.py
@@ -11,7 +11,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class DeviceAttributes(StrEnum):
     heating_power = "heating_power"
 
 
-class MideaE2Device(MiedaDevice):
+class MideaE2Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/e3/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/e3/device.py
@@ -11,7 +11,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class DeviceAttributes(StrEnum):
     target_temperature = "target_temperature"
 
 
-class MideaE3Device(MiedaDevice):
+class MideaE3Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/e6/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/e6/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class DeviceAttributes(StrEnum):
     bathing_leaving_temperature = "bathing_leaving_temperature"
 
 
-class MideaE6Device(MiedaDevice):
+class MideaE6Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/e8/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/e8/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class DeviceAttributes(StrEnum):
     water_shortage = "water_shortage"
 
 
-class MideaE8Device(MiedaDevice):
+class MideaE8Device(MideaDevice):
     _status = {
         0x00: "Standby", 0x01: "Delay", 0x02: "Working",
         0x03: "Paused", 0x04: "Keep-Warming", 0xFF: "Error"

--- a/custom_components/midea_ac_lan/midea/devices/ea/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ea/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class DeviceAttributes(StrEnum):
     progress = "progress"
 
 
-class MideaEADevice(MiedaDevice):
+class MideaEADevice(MideaDevice):
     _mode_list = [
         "smart", "reserve", "cook_rice", "fast_cook_rice", "standard_cook_rice",
         "gruel", "cook_congee", "stew_soup", "stewing", "heat_rice", "make_cake",

--- a/custom_components/midea_ac_lan/midea/devices/ec/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ec/device.py
@@ -7,7 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class DeviceAttributes(StrEnum):
     with_pressure = "with_pressure"
 
 
-class MideaECDevice(MiedaDevice):
+class MideaECDevice(MideaDevice):
     _mode_list = [
         "smart", "reserve", "cook_rice", "fast_cook_rice", "standard_cook_rice",
         "gruel", "cook_congee", "stew_soup", "stewing", "heat_rice", "make_cake",

--- a/custom_components/midea_ac_lan/midea/devices/ed/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/ed/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class DeviceAttributes(StrEnum):
     child_lock = "child_lock"
 
 
-class MideaEDDevice(MiedaDevice):
+class MideaEDDevice(MideaDevice):
 
     def __init__(
             self,

--- a/custom_components/midea_ac_lan/midea/devices/fa/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/fa/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class DeviceAttributes(StrEnum):
     oscillation_mode = "oscillation_mode"
 
 
-class MideaFADevice(MiedaDevice):
+class MideaFADevice(MideaDevice):
     _oscillation_angles = [
         "Off", "30", "60", "90", "120", "180", "360"
     ]

--- a/custom_components/midea_ac_lan/midea/devices/fb/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/fb/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     child_lock = "child_lock"
 
 
-class MideaFBDevice(MiedaDevice):
+class MideaFBDevice(MideaDevice):
     _modes = {0x01: "Auto", 0x02: "ECO", 0x03: "Sleep",
               0x04: "Anti-freezing", 0x05: "Comfort", 0x06: "Constant-temperature",
               0x07: "Normal", 0x08: "Fast-heating", 0x10: "Standby"}

--- a/custom_components/midea_ac_lan/midea/devices/fc/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/fc/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class DeviceAttributes(StrEnum):
     standby = "standby"
 
 
-class MideaFCDevice(MiedaDevice):
+class MideaFCDevice(MideaDevice):
     _modes = {
         0x00: "Standby", 0x10: "Auto", 0x20: "Manual", 0x30: "Sleep", 0x40: "Fast", 0x50: "Smoke"
     }

--- a/custom_components/midea_ac_lan/midea/devices/fd/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/fd/device.py
@@ -8,7 +8,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class DeviceAttributes(StrEnum):
     disinfect = "disinfect"
 
 
-class MideaFDDevice(MiedaDevice):
+class MideaFDDevice(MideaDevice):
     _modes = [
         "Manual", "Auto", "Continuous", "Living-Room", "Bed-Room", "Kitchen", "Sleep"
     ]

--- a/custom_components/midea_ac_lan/midea/devices/x13/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/x13/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DeviceAttributes(StrEnum):
     power = "power"
 
 
-class Midea13Device(MiedaDevice):
+class Midea13Device(MideaDevice):
     _effects = ["Manual", "Living", "Reading", "Mildly", "Cinema", "Night"]
 
     def __init__(

--- a/custom_components/midea_ac_lan/midea/devices/x26/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/x26/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class DeviceAttributes(StrEnum):
     current_temperature = "current_temperature"
 
 
-class Midea26Device(MiedaDevice):
+class Midea26Device(MideaDevice):
     _modes = ["Off", "Heat(high)", "Heat(low)", "Bath", "Blow", "Ventilation", "Dry"]
     _directions = ["60", "70", "80", "90", "100", "110", "120", "Oscillate"]
 

--- a/custom_components/midea_ac_lan/midea/devices/x34/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/x34/device.py
@@ -10,7 +10,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class DeviceAttributes(StrEnum):
     bright = "bright"
 
 
-class Midea34Device(MiedaDevice):
+class Midea34Device(MideaDevice):
     def __init__(
             self,
             name: str,

--- a/custom_components/midea_ac_lan/midea/devices/x40/device.py
+++ b/custom_components/midea_ac_lan/midea/devices/x40/device.py
@@ -9,7 +9,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from ...backports.enum import StrEnum
-from ...core.device import MiedaDevice
+from ...core.device import MideaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class DeviceAttributes(StrEnum):
     current_temperature = "current_temperature"
 
 
-class Midea40Device(MiedaDevice):
+class Midea40Device(MideaDevice):
     _directions = ["60", "70", "80", "90", "100", "Oscillate"]
 
     def __init__(

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "render_readme": true,
     "homeassistant": "2022.5",
     "zip_release": true,
-    "filename": "mieda_ac_lan.zip"
+    "filename": "midea_ac_lan.zip"
 }


### PR DESCRIPTION
Taken from here: [https://github.com/InterferencePattern/midea_ac_lan/tree/master](https://github.com/InterferencePattern/midea_ac_lan/tree/master)

Original PR description from: [https://github.com/georgezhao2010/midea_ac_lan/pull/588](https://github.com/georgezhao2010/midea_ac_lan/pull/588)

**InterferencePattern:**
After experiencing errors in installation (and the large number of issues/PRs), I found that there are many cases where "Midea" is spelled "Mieda". This discrepancy is the root cause of the error in the zip file name causing an inability to install from HACS.